### PR TITLE
- hiện thông tin đầu vào

### DIFF
--- a/coordinate_constant.py
+++ b/coordinate_constant.py
@@ -59,8 +59,8 @@ def f_fmpeg(duongdan: str, tempname: str or None = None, outmp4: str or None = N
                 ' -c copy -map 0:v -map 1:a ' + outmp4 + ' -y'
             # -c codec codec name
             # -map [-]input_file_id[:stream_specifier][,sync_file_id[:stream_s set input stream mapping
-            print('đường dẫn .out.mp4:', outmp4)
-    print(coma)
+            ifdebug: print('đường dẫn .out.mp4:', outmp4)
+    ifdebug: print(coma)
     if os.system(coma) != 0:
         readfile(temp + "text.txt", 'w', coma)
         return False

--- a/slicer2.py
+++ b/slicer2.py
@@ -127,7 +127,7 @@ class Slicer:
             pos = rms_list[silence_start: silence_end + 1].argmin() + silence_start
             sil_tags.append((pos, total_frames + 1))
         # Apply and return slices.
-        if len(sil_tags) == 0:
+        if len(sil_tags) <= 1:
             return [waveform]
         else:
             chunks = []

--- a/views.py
+++ b/views.py
@@ -4,7 +4,7 @@ from django.shortcuts import render
 import os
 
 from strlit import main_loop
-from coordinate_constant import logs_44k, cn_nes, readfile
+from coordinate_constant import logs_44k, cn_nes, readfile, osgetcwd
 
 
 @csrf_exempt
@@ -19,7 +19,8 @@ def validate(request):
       }
       
       aud___in = request.POST.get("filename")
-      with open(cn_nes, "wb") as f:  # đọc nội dung file tải lên xong ghi lại vào clean_names.wav
+      os.chdir(osgetcwd)
+      with open(f"_{cn_nes}", "wb") as f:  # đọc nội dung file tải lên xong ghi lại vào f"_{cn_nes}"
          f.write(readfile(aud___in, "rb"))
       
       f0pre = request.POST.get("f0_predictor")
@@ -39,6 +40,9 @@ def validate(request):
       model_path = request.POST.get("model_path")
       paramdict["model_path"] = f"{logs_44k_spklist}{os.sep}{model_path}"
 
+      demo = request.POST.get("demo", 0)
+      demobool: bool = False if int(demo) == 0 else True
+
       paramdict["auto_predict_f0"] = request.POST.get("auto_predict_f0", "0")
       paramdict["feature_retrieval"] = request.POST.get("feature_retrieval", "0")
       paramdict["use_spk_mix"] = request.POST.get("use_spk_mix", "0")
@@ -51,5 +55,9 @@ def validate(request):
       paramdict["clean_names"] += f'{spk_list}_{os.path.splitext(model_path)[0]}___' + \
                                   f'{os.path.splitext(aud___in.split(os.sep)[-1])[0]}.flac'
 
-      main_loop(paramdict, db_thresh, False, outlocat)
+      print(paramdict)
+      print("output_location: ", outlocat)
+      print("db_thresh: ", db_thresh)
+      if demobool: print('demo')
+      main_loop(paramdict, db_thresh, False, outlocat, demobool)
       return HttpResponse('ok')


### PR DESCRIPTION
- lược bớt phần hiện câu lệnh ffmpeg phụ thuộc cờ debug

- cờ demo nhận vào từ request qui định việc chỉ sinh ra audio đến 1 phút để làm nháp

- trỏ về thư mục gốc mỗi khi bắt đầu chương trình để tránh việc mỗi lần chạy lỗi lại phải khởi động lại

- thêm một số dòng lệnh assert và os.remove() để đảm bảo cho `os.rename()`

- tránh trường hợp trả ra output rỗng khi len(sil_tags) == 1 trong chia nhỏ audio theo khoảng lặng